### PR TITLE
Trigger DORA KPI workflow on PR

### DIFF
--- a/.github/workflows/dora-kpi.yml
+++ b/.github/workflows/dora-kpi.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
       - master
+  pull_request:
+    branches:
+      - main
+      - master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This PR updates the DORA KPI workflow to run on pull request events and triggers a second PR for testing.